### PR TITLE
🏫 Pull venue from frontmatter, not options

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -64,8 +64,8 @@
     ),
 [# endfor #]
   ),
-[# if options.venue #]
-  venue: "[-options.venue-]",
+[# if doc.venue.title #]
+  venue: "[-doc.venue.title-]",
 [# endif #]
 [# if options.logo #]
   logo: "[-options.logo-]",

--- a/template.yml
+++ b/template.yml
@@ -35,10 +35,8 @@ doc:
   - id: open_access
   - id: keywords
   - id: doi
-options:
   - id: venue
-    type: string
-    description: Venue shown in the footer
+options:
   - id: logo
     type: file
     description: An image path that is shown in the top right of the page


### PR DESCRIPTION
After recent updates to MyST CLI, frontmatter fields cannot collide with option names.

This PR removes the `venue` option, in favor of using frontmatter's `venue.title`.