### PR TITLE
Fix short_title so it renders correctly

### DIFF
--- a/examples/pixels/myst.yml
+++ b/examples/pixels/myst.yml
@@ -1,5 +1,5 @@
 title: Hello *World*
-shortTitle: cool
+short_title: cool
 author:
   - name: Rowan Cockett
     orcid: 0000-0000-0000-0000


### PR DESCRIPTION
This one needs to be `_`as per the docs, camelCase doesn't work.