### PR TITLE
Allow overriding short citation

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -27,8 +27,8 @@
 [# if doc.short_title #]
   short-title: "[-doc.short_title-]",
 [# endif #]
-[# if doc.short_citation #]
-  citation: "[-doc.short_citation-]",
+[# if options.short_citation #]
+  short-citation: "[-options.short_citation-]",
 [# endif #]
 [# if doc.open_access !== undefined #]
   open-access: [-doc.open_access-],

--- a/template.typ
+++ b/template.typ
@@ -30,6 +30,9 @@
 [# if options.short_citation #]
   short-citation: "[-options.short_citation-]",
 [# endif #]
+[# if options.heading_numbering #]
+  heading-numbering: "[-options.heading_numbering-]",
+[# endif #]
 [# if doc.open_access !== undefined #]
   open-access: [-doc.open_access-],
 [# endif #]

--- a/template.typ
+++ b/template.typ
@@ -27,6 +27,9 @@
 [# if doc.short_title #]
   short-title: "[-doc.short_title-]",
 [# endif #]
+[# if doc.short_citation #]
+  citation: "[-doc.short_citation-]",
+[# endif #]
 [# if doc.open_access !== undefined #]
   open-access: [-doc.open_access-],
 [# endif #]

--- a/template.yml
+++ b/template.yml
@@ -32,6 +32,7 @@ doc:
     required: true
   - id: subtitle
   - id: short_title
+  - id: short_citation
   - id: open_access
   - id: keywords
   - id: doi

--- a/template.yml
+++ b/template.yml
@@ -48,6 +48,11 @@ options:
     description: |
       The short citation used in the document header. By default, it
       is automatically determined from the author names.
+  - id: heading_numbering
+    type: string
+    description: |
+      Heading numbering style.
+      See also https://typst.app/docs/reference/model/numbering/.
 
 parts:
   - id: abstract

--- a/template.yml
+++ b/template.yml
@@ -32,7 +32,6 @@ doc:
     required: true
   - id: subtitle
   - id: short_title
-  - id: short_citation
   - id: open_access
   - id: keywords
   - id: doi
@@ -44,6 +43,11 @@ options:
   - id: kind
     type: string
     description: The "kind" of the content, e.g. "Original Research" - shown as the title of the margin content on the first page
+  - id: short_citation
+    type: string
+    description: |
+      The short citation used in the document header. By default, it
+      is automatically determined from the author names.
 
 parts:
   - id: abstract


### PR DESCRIPTION
(@rowanc1 asked me to open a draft PR to discuss this behavior I'm seeing.)

I'm trying to allow the template to take a `short_citation` option, so that I can fix an incorrectly summarized last name.

However, when I try and load this in my document via:

```
exports:
  - format: typst
    template: /home/stefan/p/myst/lapreprint-typst
    output: exports/report.pdf
```

`myst` CLI complains:

```
⛔️ report.md 'id' invalid value 'short_citation' - must be one of
[date, doi, identifiers, open_access, license, binder, source,
subject, volume, issue, first_page, last_page, oxa, numbering,
bibliography, math, abbreviations, exports, downloads, settings,
edit_url, arxiv, pmid, pmcid, zenodo, title, subtitle, short_title,
description, thumbnail, thumbnailOptimized, banner, bannerOptimized,
tags, authors, reviewers, editors, contributors, venue, github,
keywords, affiliations, funding, copyright, options, parts, abstract,
summary, keypoints, dedication, epigraph, data_availability,
acknowledgments, label, kernelspec, jupytext, tags, site, enumerator,
content_includes_title, skip_execution] (at
/home/stefan/p/myst/lapreprint-typst/template.yml#template.doc.4)

Error: Cannot use invalid template.yml:
/home/stefan/p/myst/lapreprint-typst/template.yml
```