### PR TITLE
⚖️ Fix type comparisons

### DIFF
--- a/lapreprint.typ
+++ b/lapreprint.typ
@@ -50,9 +50,9 @@
   let spacer = text(fill: gray)[#h(8pt) | #h(8pt)]
 
   let dates;
-  if (type(date) == "datetime") {
+  if (type(date) == datetime) {
     dates = ((title: "Published", date: date),)
-  } else if (type(date) == "dictionary") {
+  } else if (type(date) == dictionary) {
     dates = (date,)
   } else {
     dates = date
@@ -185,7 +185,7 @@
       box(
         width: 27%,
         {
-          if (type(logo) == "content") {
+          if (type(logo) == content) {
             logo
           } else {
             image(logo, width: 100%)
@@ -273,7 +273,7 @@
 
 
   let abstracts
-  if (type(abstract) == "content" or type(abstract) == "string") {
+  if (type(abstract) == content or type(abstract) == str) {
     abstracts = ((title: "Abstract", content: abstract),)
   } else {
     abstracts = abstract


### PR DESCRIPTION
Building with newer versions of typst now gives a list of warnings about type comparisons. This patch gets rid of that warning. I don't know typst very well yet, so please check if the types, especially `str`, are correct.